### PR TITLE
Fix keypress not working in Firefox (issue #6)

### DIFF
--- a/rTerm.js
+++ b/rTerm.js
@@ -152,7 +152,7 @@ rTerm = function (options) {
 
     this.keyCallback = (function(event) {
         if (event.which != 13) {
-            this.addCallback(String.fromCharCode(event.keyCode));
+            this.addCallback(event.key);
         }
     }).bind(this);
 


### PR DESCRIPTION
The problem is that event.keyCode (deprecated) contains only one byte,
so String.fromCharCode(event.keyCode) only gets a part of UTF8 symbol.

Replaced with event.key.
Tested in Chrome and Firefox.